### PR TITLE
Update preprocess.py

### DIFF
--- a/preprocess.py
+++ b/preprocess.py
@@ -217,19 +217,19 @@ def split_data(idir, odir):
     with open(trainp, 'w') as wfile:
         wfile.write(cols)
         for idx in range(int(len(indices)*.7)):
-            wfile.write(corpus[idx])
+            wfile.write(corpus[indices[idx]])
 
     # valid
     with open(validp, 'w') as wfile:
         wfile.write(cols)
         for idx in range(int(len(indices)*.7), int(len(indices)*.85)):
-            wfile.write(corpus[idx])
+            wfile.write(corpus[indices[idx]])
 
     # test
     with open(testp, 'w') as wfile:
         wfile.write(cols)
         for idx in range(int(len(indices)*.85), len(indices)):
-            wfile.write(corpus[idx])
+            wfile.write(corpus[indices[idx]])
 
 
 def build_indices(split_dir, tok, indices_dir, max_len=40):


### PR DESCRIPTION
In the splitting dataset function, indices were shuffled but not used in the later process. For example, as shown here, 
https://github.com/xiaoleihuang/Multilingual_Fairness_LREC/blob/70067aaf4a92f60967eb5859dbb3482b2c0bc66f/preprocess.py#L219, the first 70% instances were selected to be train set (without using shuffled indices). 